### PR TITLE
Add protocol message for "signal" message type to libssh2.

### DIFF
--- a/libssh2/include/libssh2.h
+++ b/libssh2/include/libssh2.h
@@ -756,6 +756,7 @@ LIBSSH2_API int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
                                           const char *value,
                                           unsigned int value_len);
 
+
 #define libssh2_channel_setenv(channel, varname, value)                 \
     libssh2_channel_setenv_ex((channel), (varname),                     \
                               (unsigned int)strlen(varname), (value),   \
@@ -791,6 +792,13 @@ LIBSSH2_API int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel,
                                            int screen_number);
 #define libssh2_channel_x11_req(channel, screen_number) \
  libssh2_channel_x11_req_ex((channel), 0, NULL, NULL, (screen_number))
+
+LIBSSH2_API int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
+                                          const char *signame,
+                                          unsigned int signame_len);
+#define libssh2_channel_signal(channel, signame) \
+ libssh2_channel_signal_ex((channel), signame, (unsigned int)strlen(signame))
+
 
 LIBSSH2_API int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                                 const char *request,

--- a/libssh2/src/channel.c
+++ b/libssh2/src/channel.c
@@ -869,8 +869,7 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
     if(channel->setenv_state == libssh2_NB_state_sent) {
         rc = _libssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                       1, channel->setenv_local_channel, 4,
-                                      &channel->
-                                      setenv_packet_requirev_state);
+                                      &channel->setenv_packet_requirev_state);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             return rc;
         }
@@ -2735,4 +2734,84 @@ libssh2_channel_window_write_ex(LIBSSH2_CHANNEL *channel,
     }
 
     return channel->local.window_size;
+}
+
+/* A signal can be delivered to the remote process/service using the
+   following message.  Some systems may not implement signals, in which
+   case they SHOULD ignore this message.
+
+      byte      SSH_MSG_CHANNEL_REQUEST
+      uint32    recipient channel
+      string    "signal"
+      boolean   FALSE
+      string    signal name (without the "SIG" prefix)
+
+   'signal name' values will be encoded as discussed in the passage
+   describing SSH_MSG_CHANNEL_REQUEST messages using "exit-signal" in
+   this section.
+*/
+static int channel_signal(LIBSSH2_CHANNEL *channel,
+                          const char *signame, unsigned int signame_len)
+{
+    LIBSSH2_SESSION *session = channel->session;
+    unsigned char *s;
+    int rc;
+    int retcode = LIBSSH2_ERROR_PROTO;
+
+    if(channel->sendsignal_state == libssh2_NB_state_idle) {
+
+        /* 20 = packet_type(1) + channel(4) + signal_len + sizeof(signal) - 1 + want_reply(1) +
+         * signame_len_len(4) */
+        channel->sendsignal_packet_len = 20 + signame_len;
+
+        s = channel->sendsignal_packet = LIBSSH2_ALLOC(session, channel->sendsignal_packet_len);
+        if(!channel->sendsignal_packet)
+            return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                  "Unable to allocate memory for signal request");
+
+        *(s++) = SSH_MSG_CHANNEL_REQUEST;
+        _libssh2_store_u32(&s, channel->remote.id);
+        _libssh2_store_str(&s, "signal", sizeof("signal") - 1);
+        *(s++) = 0x00; /* Don't reply */
+        _libssh2_store_str(&s, signame, signame_len);
+
+        channel->sendsignal_state = libssh2_NB_state_created;
+    }
+
+    if(channel->sendsignal_state == libssh2_NB_state_created) {
+
+        rc = _libssh2_transport_send(session, channel->sendsignal_packet,
+                                     channel->sendsignal_packet_len,
+                                     NULL, 0);
+        if(rc == LIBSSH2_ERROR_EAGAIN) {
+            _libssh2_error(session, rc, "Would block sending signal request");
+            return rc;
+        }
+        else if(rc) {
+            LIBSSH2_FREE(session, channel->sendsignal_packet);
+            channel->sendsignal_state = libssh2_NB_state_idle;
+            return _libssh2_error(session, rc, "Unable to send signal packet");
+        }
+        LIBSSH2_FREE(session, channel->sendsignal_packet);
+        retcode = LIBSSH2_ERROR_NONE;
+
+    }
+    channel->sendsignal_state = libssh2_NB_state_idle;
+    return retcode;
+
+}
+
+LIBSSH2_API int
+libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
+                          const char *signame,
+                          unsigned int signame_len)
+{
+    int rc;
+
+    if(!channel)
+        return LIBSSH2_ERROR_BAD_USE;
+
+    BLOCK_ADJUST(rc, channel->session,
+                 channel_signal(channel, signame, signame_len));
+    return rc;
 }

--- a/libssh2/src/libssh2_priv.h
+++ b/libssh2/src/libssh2_priv.h
@@ -452,6 +452,10 @@ struct _LIBSSH2_CHANNEL
     /* State variables used in libssh2_channel_handle_extended_data2() */
     libssh2_nonblocking_states extData2_state;
 
+    /* State variables used in libssh2_channel_signal_ex() */
+    libssh2_nonblocking_states sendsignal_state;
+    unsigned char *sendsignal_packet;
+    size_t sendsignal_packet_len;
 };
 
 struct _LIBSSH2_LISTENER

--- a/ssh2/c_ssh2.pxd
+++ b/ssh2/c_ssh2.pxd
@@ -229,6 +229,13 @@ cdef extern from "libssh2.h" nogil:
     int libssh2_channel_setenv(LIBSSH2_CHANNEL *channel,
                                const char *varname,
                                const char *value)
+    int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
+                                  const char *signalname,
+                                  unsigned int signalname_len,
+                                 )
+    int libssh2_channel_signal(LIBSSH2_CHANNEL *channel,
+                                  const char *signalname,
+                                 )
     int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel,
                                        const char *term,
                                        unsigned int term_len,


### PR DESCRIPTION
Also add Cython wrapper support for it.
For some reason this was missing.
NB: older openssh servers don't support that message. 7.x seems not to,
but 8.x does.